### PR TITLE
Remove Agentic AI Use Cases from top navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,7 +56,6 @@ defaults:
 
 # Header navigation pages (in order)
 header_pages:
-  - ai-use-cases/index.md
   - blog.md
   - about.md
 


### PR DESCRIPTION
## Summary
Removes the **Agentic AI Use Cases** link from the site's top navigation bar.

### What changed
- Removed `ai-use-cases/index.md` from `header_pages` in `_config.yml`
- The page content (`ai-use-cases/`) is **not** deleted — it remains accessible by direct URL

Fixes #25