### PR TITLE
Post: AI Agents Aren't Just for Engineers

### DIFF
--- a/_posts/2026-03-07-ai-agents-arent-just-for-engineers.md
+++ b/_posts/2026-03-07-ai-agents-arent-just-for-engineers.md
@@ -1,0 +1,124 @@
+---
+layout: post
+title: "AI Agents Aren't Just for Engineers. Here's How to Get Started."
+date: 2026-03-07 12:00:00 -0000
+categories: [AI, Future of Work]
+tags: [AI, Agents, Copilot, Automation, No-Code]
+excerpt: "You don't need to write code to have AI agents working for you. Here's the practical, non-intimidating guide to building your own agent team."
+---
+
+Last year, I wrote about how [your job isn't obsolete, your workflow is](/2025/07/09/your-job-isnt-obsolete-your-workflow-is/). That post was about the *why*: why AI is changing the shape of work, and why the smart play is to lean in rather than panic. A lot of people read it, and a lot of people wrote back with the same follow-up question:
+
+*"OK, I get it. But how do I actually start?"*
+
+Fair question. And if you've been poking around for answers, you've probably noticed that most of the AI-agent content out there reads like it was written by engineers, for engineers. It's full of framework comparisons, architecture diagrams, and code snippets that assume you already know what a "multi-agent orchestration layer" is. Which is great if you're a developer. Less great if you're a marketing manager, a project lead, an analyst, or anyone else who works at a computer and suspects there's a better way.
+
+So let me be direct: **you don't need to be an engineer to have AI agents working for you.** You don't need to write code. You don't need to understand neural network architectures. You need a clear idea of what you want to get done, and a willingness to think about your work a little differently.
+
+This is the practical getting-started guide I wish existed six months ago.
+
+## First, What Even Is an "Agent"?
+
+The word "agent" gets thrown around a lot right now, and half the time people mean different things by it. So let's be precise.
+
+A regular AI chatbot is reactive. You ask it a question, it gives you an answer, you move on. It's like texting a very well-read friend.
+
+An AI *agent* is proactive. You give it a goal, and it figures out the steps to get there. It can break a task into subtasks, use tools, check its own work, and iterate until the job is done. It's less like texting a friend and more like delegating to a capable junior associate (one who works at 3 AM without complaining about it).
+
+When GitHub launched [Copilot's agent mode](https://github.blog/news-insights/product-news/github-copilot-the-agent-awakens/) in early 2025, this is exactly what it demonstrated: an AI that could infer subtasks, run commands, and self-correct errors autonomously. That was a developer tool. But the pattern (give a goal, let the agent figure it out) is universal.
+
+## Why This Matters Right Now
+
+This isn't theoretical anymore. The infrastructure is arriving fast.
+
+[Microsoft's 2025 Work Trend Index](https://www.microsoft.com/en-us/worklab/work-trend-index/2025-the-year-the-frontier-firm-is-born) found that **82% of leaders** expect agents to be moderately or extensively integrated into their company's AI strategy within 12–18 months. Not "someday." Not "when the technology matures." Within the next year.
+
+Meanwhile, **53% of leaders** say productivity must increase, but **80% of the global workforce** reports lacking the time or energy to keep up. Something has to give. The answer, increasingly, is digital labor: AI agents that handle the repetitive, time-consuming work so humans can focus on the parts that actually require human judgment.
+
+In February 2026, GitHub launched [Agent HQ](https://github.blog/news-insights/company-news/pick-your-agent-use-claude-and-codex-on-agent-hq/), letting users run multiple coding agents from different providers (Copilot, Claude, Codex) inside a single workspace. It's a "pick your agent" model. And while Agent HQ is aimed at developers today, the pattern it represents is coming for every knowledge worker: choose the right agent for the right task, orchestrate them together, get more done.
+
+The mental model is the thing that hasn't caught up. The tools are here. The question is whether you're ready to use them.
+
+## Your First Hire Should Be an Agent
+
+Here's the framing that made this click for me: stop thinking of AI agents as software. Start thinking of them as your first hire.
+
+If you run a small team or work independently, you know the pain of wearing too many hats. You're doing the strategic thinking *and* the data pulling *and* the meeting scheduling *and* the report formatting. You'd love to delegate, but there's no budget for another headcount.
+
+An agent is that headcount... minus the salary negotiation.
+
+Imagine you're a marketing manager. What if you had:
+
+- A **research agent** that monitors competitor announcements, industry reports, and social trends, then summarizes what matters every morning
+- A **writing-assist agent** that drafts first versions of campaign briefs, email sequences, and social posts based on your brand guidelines
+- A **scheduling agent** that coordinates meeting times across stakeholders without the 14-email chain
+
+None of these require building custom software. They require defining what you need and pointing the right tool at it. That's management, not engineering.
+
+## The Work Chart vs. the Org Chart
+
+Microsoft's Work Trend Index introduced a concept I keep coming back to: the **Work Chart**. The idea is simple but powerful.
+
+Your org chart shows who reports to whom. It's static. It reflects hierarchy.
+
+A Work Chart shows how work actually flows: who (and what) contributes to getting something done. And increasingly, "what" includes agents. Teams form around goals, not functions, and they include both humans and AI agents. When the goal is achieved, the team reshuffles.
+
+Microsoft calls this the "[Frontier Firm](https://www.microsoft.com/en-us/worklab/work-trend-index/2025-the-year-the-frontier-firm-is-born)," a company that runs on hybrid teams of humans and agents, scaling capacity up and down like a film production. You assemble the team for the project, do the work, and disband. The agents don't need to be "hired" or "fired"; they're just there when you need them and idle when you don't.
+
+At [companies already doing this](https://www.microsoft.com/en-us/worklab/agents-are-here-is-your-company-prepared), the results are striking. Microsoft's research found that "Achiever" companies (those with both strong AI strategy *and* execution) deploy agents roughly 2.5 times faster than companies still in discovery mode. The differentiator isn't budget. It's preparation and willingness to try.
+
+## OK, But How Do I Actually Start? (No Code Required)
+
+Here's where it gets practical. There are real tools, available today, that let non-engineers build and configure AI agents without writing a single line of code.
+
+### Microsoft Copilot Studio
+
+[Copilot Studio](https://www.microsoft.com/en-us/microsoft-copilot/microsoft-copilot-studio) is Microsoft's no-code agent builder. You can create custom agents that plug into your existing Microsoft 365 environment: pulling data from SharePoint, responding to Teams messages, automating approval workflows. If you can fill out a form and describe what you want in plain English, you can build an agent here.
+
+This is probably the lowest-friction starting point for anyone already in the Microsoft ecosystem. You're not "coding." You're configuring. And the difference matters.
+
+### Zapier and Other Automation Platforms
+
+If you've ever built a Zap ("when I get an email with this label, save the attachment to this folder") you already understand the mental model. The newer generation of automation tools adds AI agents into the mix. Your automations can now include steps like "summarize this document," "classify this support ticket," or "draft a response in this tone." The workflow is visual, drag-and-drop, point-and-click.
+
+### The Framework Landscape (For the Curious)
+
+If you *are* a little technical, or if you're working with someone who is, it's worth knowing that multi-agent frameworks are proliferating fast. [CrewAI](https://github.com/crewAIInc/crewAI), Microsoft's [AutoGen](https://github.com/microsoft/autogen), and LangGraph all let you orchestrate teams of agents that collaborate on complex tasks: research, writing, analysis, code review. These do require some code. But they're worth knowing about because they represent where things are heading: not one agent, but a *team* of agents, each with a specialty, working together.
+
+Think of it as the difference between hiring one generalist and assembling a squad.
+
+## The Human-Agent Ratio
+
+Here's a question that's going to be on every leader's mind in the next 18 months: *how many agents for which roles, and how many humans to guide them?*
+
+Microsoft's WTI data shows that **45% of leaders** say expanding team capacity with digital labor is a top priority. And some early adopters are already proving the model at a remarkable scale. The report profiles solo founders and tiny startups using AI agents to compete with much larger teams: one founder on track for $2M/year with an AI-powered staffing firm, a 5-person startup using agents for everything from construction simulations to market research, [boosting margins by 20%](https://www.microsoft.com/en-us/worklab/work-trend-index/2025-the-year-the-frontier-firm-is-born).
+
+You don't need to go that far. Start by asking yourself: **what's the most repetitive, time-consuming part of my week?** That's your first agent use case. Not the strategic thinking. Not the relationship building. The stuff that eats your time without engaging your brain. *That's* what you delegate to an agent.
+
+## Three Things to Get Right
+
+Before you go spinning up agents for everything, a few principles that will save you from the most common mistakes:
+
+**1. Start small and specific.** Don't try to build a "general assistant that handles everything." That's a recipe for an agent that handles nothing well. Pick one specific task (summarizing weekly reports, drafting meeting agendas, monitoring a competitor's blog) and get that working reliably before expanding.
+
+**2. Stay in the loop.** Agents are capable, not infallible. The best pattern right now is "agent does the first draft, human does the review." You're the editor-in-chief, not the typist. This is the [human-in-the-loop model](/2025/07/09/your-job-isnt-obsolete-your-workflow-is/) I talked about before. Your judgment is the quality gate.
+
+**3. Think in workflows, not features.** Don't ask "what can this AI tool do?" Ask "what does my workflow look like, and where does an agent slot in?" The tool's feature list is irrelevant if it doesn't map to the way you actually work.
+
+## The Part Where I'm Honest About the Limitations
+
+Agents are not magic. They hallucinate. They misunderstand context. They sometimes do the wrong thing with great confidence. If you hand an agent a vague goal with no guardrails, you'll get vague results... or worse, confidently wrong ones.
+
+The good news is that this is a solvable problem. Clear instructions, defined boundaries, and human review make agents dramatically more reliable. The same skills that make you good at managing people (clear communication, well-defined expectations, regular check-ins) make you good at managing agents.
+
+The other honest truth: the no-code tools are good and getting better, but they're not as flexible as writing code. If you have a very custom, very complex workflow, you might hit the ceiling of what point-and-click can do. That's fine. Start with no-code, learn the concepts, and if you eventually need more power, you'll have the mental model to work with a developer who can build something custom. You don't need to know how to build an engine to drive a car, but understanding what the engine does makes you a better driver.
+
+## What Happens Next
+
+We're at a genuinely interesting inflection point. The tools for non-engineers to build and use AI agents have gone from "theoretically possible" to "available on your laptop" in about 18 months. The gap isn't technology anymore. It's imagination.
+
+The people who will get the most out of this moment aren't the ones waiting for a perfect, fully-packaged solution. They're the ones willing to experiment, to start small, to treat an AI agent like a new team member who needs clear direction and a bit of patience.
+
+I said it before and I'll say it again: [the future belongs to those who pick up the new tools and build something](/2025/07/09/your-job-isnt-obsolete-your-workflow-is/). The tools just got a lot more accessible. The only question left is what you're going to build with them.
+
+Your first agent is waiting. Go give it something to do.


### PR DESCRIPTION
Publishes the AI agents blog post for non-engineers audience.

Closes #20